### PR TITLE
Refactor Enum Operation

### DIFF
--- a/compiler/BasicBlock.cpp
+++ b/compiler/BasicBlock.cpp
@@ -25,6 +25,6 @@ void BasicBlock::gen_asm(ostream &o){
     }
 }
 
-void BasicBlock::add_IRInstr(IRInstr::Operation op, Type t, vector<string> params) {
+void BasicBlock::add_IRInstr(Operation op, Type t, vector<string> params) {
     instrs.push_back(new IRInstr(this, op, t, params));
 }

--- a/compiler/BasicBlock.h
+++ b/compiler/BasicBlock.h
@@ -8,6 +8,7 @@
 
 // Declarations from the parser -- replace with your own
 #include "Type.h"
+#include "Operation.h"
 
 #include "CFG.h"
 #include "IRInstr.h"
@@ -15,6 +16,7 @@
 using namespace std;
 
 class CFG;
+class IRInstr;
 
 /**  The class for a basic block */
 
@@ -47,7 +49,7 @@ class BasicBlock {
 	BasicBlock(CFG* cfg, string entry_label);
 	void gen_asm(ostream &o); /**< x86 assembly code generation for this basic block (very simple) */
 
-	void add_IRInstr(IRInstr::Operation op, Type t, vector<string> params);
+	void add_IRInstr(Operation op, Type t, vector<string> params);
 
 	// No encapsulation whatsoever here. Feel free to do better.
 	BasicBlock* exit_true;  /**< pointer to the next basic block, true branch. If nullptr, return from procedure */ 

--- a/compiler/IRInstr.cpp
+++ b/compiler/IRInstr.cpp
@@ -8,11 +8,12 @@ IRInstr::IRInstr(BasicBlock* bb_, Operation op, Type t, vector<string> params) {
 }
 
 void IRInstr::gen_asm(ostream &o) {
+
     switch (op) {
         case ldconst:
             o << "    movl    $" << params[1] << ", " << params[0] << "\n";
             break;
-        case copy:
+        case 1: //copy
             o << "    movl    " << params[1] << ", %eax\n";
             o << "    movl %eax, " << params[0] << "\n";
             break;
@@ -30,8 +31,8 @@ void IRInstr::gen_asm(ostream &o) {
             o << "    movl    " << params[2] << "(%eax), " << params[0] << "\n";
             break;
         case wmem:
-            o << "    movl    " << params[1] << ", %eax" << "\n";
-            o << "    movl    " << params[0] << ", " << params[2] << "(%eax)" << "\n";
+            o << "    movl    " << bb->cfg->get_var_index(params[0]) << ", %eax" << "\n";
+            o << "    movl    %eax, -" << bb->cfg->get_var_index(params[1]) << "(%rbp)" << "\n";
             break;
         case call:
             o << "    call    " << params[0] << "\n";

--- a/compiler/IRInstr.h
+++ b/compiler/IRInstr.h
@@ -6,7 +6,9 @@
 #include <iostream>
 #include <initializer_list>
 
+#include "BasicBlock.h"
 #include "Type.h"
+#include "Operation.h"
 
 class BasicBlock;
 
@@ -16,21 +18,6 @@ using namespace std;
 class IRInstr {
  
    public:
-	/** The instructions themselves -- feel free to subclass instead */
-	typedef enum {
-		ldconst,
-		copy,
-		add,
-		sub,
-		mul,
-		rmem,
-		wmem,
-		call, 
-		cmp_eq,
-		cmp_lt,
-		cmp_le
-	} Operation;
-
 
 	/**  constructor */
 	IRInstr(BasicBlock* bb_, Operation op, Type t, vector<string> params);

--- a/compiler/Operation.h
+++ b/compiler/Operation.h
@@ -1,0 +1,23 @@
+//
+// Created by arthur on 19/03/24.
+//
+
+#ifndef PLD_COMP_OPERATION_H
+#define PLD_COMP_OPERATION_H
+
+/** The instructions themselves -- feel free to subclass instead */
+typedef enum {
+    ldconst = 0,
+    copy = 1,
+    add = 2,
+    sub = 3,
+    mul = 4,
+    rmem = 5,
+    wmem = 6,
+    call = 7,
+    cmp_eq = 8,
+    cmp_lt = 9,
+    cmp_le = 10
+} Operation;
+
+#endif //PLD_COMP_OPERATION_H


### PR DESCRIPTION
On déplace l'enum de opération parce que ça semble plus clair pour nous et plus simple à utiliser.