### PR TITLE
Make variable start from rbp-4 otherwise we overwrite previous rbp

### DIFF
--- a/compiler/CFG.cpp
+++ b/compiler/CFG.cpp
@@ -2,7 +2,7 @@
 #include "BasicBlock.h"
 
 CFG::CFG() {
-    nextFreeSymbolIndex = 0;
+    nextFreeSymbolIndex = 4;
     current_bb = nullptr;
     nextBBnumber = 0;
     nextTmpVariableNumber = 0;


### PR DESCRIPTION
rbp serves as a base pointer to the stack frame allowing us to access local variables and arguments.
The local variables are located just above rbp (-4%rbp, -8%rbp etc...) and the function's arguments are located
just below (+4%rbp, +8%rbp etc...) however right at 0%rbp we have stored the rbp value for the previous stack frame;
this is because of the way the setup of the stack frame works (push %rbp then mov %rbp, %rsp).
If the indexes for our variables start at 0 like its the case in our code, then the first variable would overwrite the previous value of rbp and when we get  back into the calling function %rbp will no longer be pointing to the base of the stack frame...

Solution : just make the indices start from 4